### PR TITLE
Fix Before ( when previous token is , or (

### DIFF
--- a/features/indent.feature
+++ b/features/indent.feature
@@ -449,6 +449,24 @@ Feature: hyai indent
     And I call hyai-indent-candidates at the current point
     Then indent candidates are "(9 0)"
 
+    Given the buffer is empty
+    When I insert:
+    """
+    import Control.Applicative (
+    (<$>)
+    """
+    And I call hyai-indent-candidates at the current point
+    Then indent candidates are "(29)"
+
+    Given the buffer is empty
+    When I insert:
+    """
+    import Data.Monoid ( mempty,
+    (<>)
+    """
+    And I call hyai-indent-candidates at the current point
+    Then indent candidates are "(21)"
+
   Scenario: Before )
     Given the buffer is empty
     When I insert:


### PR DESCRIPTION
e.g. for operator in import spec.

Refactor hyai--indent-candidates-from-previous by using
hyai--grab-token.

Bump version to v1.3.4.
