### PR TITLE
Remove emacs-snapshot from Travis build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 env:
   - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
 
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh


### PR DESCRIPTION
It fails sometimes.
Add emacs-24.4 instead.
