### PR TITLE
Add second argument to looking-back function

### DIFF
--- a/hyai.el
+++ b/hyai.el
@@ -572,7 +572,7 @@ Process is stopped at the optional LIMIT position."
              (comm-type (nth 4 ppss)))
         (cond
          (comm-type (hyai--goto-comment-start ppss))
-         ((and (= c ?\}) (looking-back "-}"))
+         ((and (= c ?\}) (looking-back "-}" limit))
           (backward-char)
           (hyai--goto-comment-start ppss))
          (t


### PR DESCRIPTION
In Emacs 25.1 is a non optional argument. 
See: https://github.com/emacs-mirror/emacs/commit/5161c9c
